### PR TITLE
Health broken during init

### DIFF
--- a/health.go
+++ b/health.go
@@ -3,11 +3,9 @@ package storageos
 import (
 	"context"
 	"encoding/json"
-	//"errors"
-	//"fmt"
-	"github.com/storageos/go-api/types"
 	"net/http"
-	//"net/url"
+
+	"github.com/storageos/go-api/types"
 )
 
 var (
@@ -16,7 +14,7 @@ var (
 )
 
 // CPHealth returns the health of the control plane server at a given url.
-func (c *Client) CPHealth(hostname string) (*types.CPHealthStatus, error) {
+func (c *Client) CPHealth(ctx context.Context, hostname string) (*types.CPHealthStatus, error) {
 
 	req, err := http.NewRequest("GET", "http://"+hostname+":5705/v1/"+HealthAPIPrefix, nil)
 	if err != nil {
@@ -28,7 +26,7 @@ func (c *Client) CPHealth(hostname string) (*types.CPHealthStatus, error) {
 		req.SetBasicAuth(c.username, c.secret)
 	}
 
-	resp, err := c.HTTPClient.Do(req.WithContext(context.Background()))
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +41,7 @@ func (c *Client) CPHealth(hostname string) (*types.CPHealthStatus, error) {
 }
 
 // DPHealth returns the health of the data plane server at a given url.
-func (c *Client) DPHealth(hostname string) (*types.DPHealthStatus, error) {
+func (c *Client) DPHealth(ctx context.Context, hostname string) (*types.DPHealthStatus, error) {
 
 	req, err := http.NewRequest("GET", "http://"+hostname+":8001/v1/"+HealthAPIPrefix, nil)
 	if err != nil {
@@ -55,7 +53,7 @@ func (c *Client) DPHealth(hostname string) (*types.DPHealthStatus, error) {
 		req.SetBasicAuth(c.username, c.secret)
 	}
 
-	resp, err := c.HTTPClient.Do(req.WithContext(context.Background()))
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/health_test.go
+++ b/health_test.go
@@ -1,6 +1,7 @@
 package storageos
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -45,7 +46,7 @@ func TestCPHealth(t *testing.T) {
 	}
 
 	client := newTestClient(&FakeRoundTripper{message: data, status: http.StatusOK})
-	cpHealth, err := client.CPHealth("someHostname")
+	cpHealth, err := client.CPHealth(context.Background(), "someHostname")
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +97,7 @@ func TestDPHealth(t *testing.T) {
 	}
 
 	client := newTestClient(&FakeRoundTripper{message: data, status: http.StatusOK})
-	dpHealth, err := client.DPHealth("someHostname")
+	dpHealth, err := client.DPHealth(context.Background(), "someHostname")
 	if err != nil {
 		t.Error(err)
 	}

--- a/types/node.go
+++ b/types/node.go
@@ -25,10 +25,10 @@ type CPHealthStatus struct {
 
 func (c *CPHealthStatus) ToNamedSubmodules() []NamedSubModuleStatus {
 	return []NamedSubModuleStatus{
-		{Name: "NATS", SubModuleStatus: c.NATS},
-		{Name: "KV", SubModuleStatus: c.KV},
-		{Name: "KV_WRITE", SubModuleStatus: c.KVWrite},
-		{Name: "SCHEDULER", SubModuleStatus: c.Scheduler},
+		{Name: "nats", SubModuleStatus: c.NATS},
+		{Name: "kv", SubModuleStatus: c.KV},
+		{Name: "kv_write", SubModuleStatus: c.KVWrite},
+		{Name: "scheduler", SubModuleStatus: c.Scheduler},
 	}
 }
 
@@ -64,11 +64,11 @@ type DPHealthStatus struct {
 
 func (d *DPHealthStatus) ToNamedSubmodules() []NamedSubModuleStatus {
 	return []NamedSubModuleStatus{
-		{Name: "DFS_CLIENT", SubModuleStatus: d.DirectFSClient},
-		{Name: "DFS_SERVER", SubModuleStatus: d.DirectFSServer},
-		{Name: "DIRECTOR", SubModuleStatus: d.Director},
-		{Name: "FS_DRIVER", SubModuleStatus: d.FSDriver},
-		{Name: "FS", SubModuleStatus: d.FS},
+		{Name: "dfs_client", SubModuleStatus: d.DirectFSClient},
+		{Name: "dfs_server", SubModuleStatus: d.DirectFSServer},
+		{Name: "director", SubModuleStatus: d.Director},
+		{Name: "fs_driver", SubModuleStatus: d.FSDriver},
+		{Name: "fs", SubModuleStatus: d.FS},
 	}
 }
 


### PR DESCRIPTION
Adds context param to the healthchecks that go direct to nodes so that we can add a short timeout.  Currently they hang if there is no connectivity (client uses service address for the API, but the nodes are on private addresses.

Also lowercases the submodule names.