### PR TITLE
refactor: extract method Client.doAddress 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Test coverage
+cov
+cov.html

--- a/client_test.go
+++ b/client_test.go
@@ -469,6 +469,28 @@ func TestClientDoNewOrderParallel(t *testing.T) {
 
 }
 
+func TestClientDoNode(t *testing.T) {
+	// Create a good server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.doNode(context.Background(), "POST", srv.URL, VolumeAPIPrefix, &doOptions{
+		namespace: "testns",
+	})
+	if err != nil {
+		t.Fatalf("expected: nil error, got: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected: status %d, got: %d", http.StatusOK, resp.StatusCode)
+	}
+}
+
 type FakeRoundTripper struct {
 	message  string
 	status   int


### PR DESCRIPTION
This refactoring is intended to support the health check API which requires the Client to provide a request method to a single node.

* Extract method Client.doAddress from the inner iteration of Client.do
* Wrap it with doNode to provide a convenient request method to a single node
* Test doNode

The refactoring is done to prevent duplicated code while minimising the code changes.
