### PR TITLE
Don't fail silently on unrecognised error conditions

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -110,7 +110,7 @@ func (c *Client) PoolDelete(opts types.DeleteOptions) error {
 				return ErrPoolInUse
 			}
 		}
-		return nil
+		return err
 	}
 	defer resp.Body.Close()
 	return nil

--- a/rule.go
+++ b/rule.go
@@ -134,7 +134,7 @@ func (c *Client) RuleDelete(opts types.DeleteOptions) error {
 				return ErrRuleInUse
 			}
 		}
-		return nil
+		return err
 	}
 	defer resp.Body.Close()
 	return nil


### PR DESCRIPTION
In some cases we were hiding API errors from the caller, this caused issues like the cli thinking an unauthenticated user could delete pools.