### PR TITLE
Add DialContext option to v1 client

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,6 +44,9 @@ var (
 	// ErrProxyNotSupported is returned when a client is unable to set a proxy for http requests.
 	ErrProxyNotSupported = errors.New("client does not support http proxy")
 
+	// ErrDialerNotSupported is returned when a client is unable to set a DialContext for http requests.
+	ErrDialerNotSupported = errors.New("client does not support setting DialContext")
+
 	// DefaultPort is the default API port.
 	DefaultPort = "5705"
 
@@ -106,6 +109,8 @@ func (c *Client) ClientVersion() string {
 type Dialer interface {
 	Dial(network, address string) (net.Conn, error)
 }
+
+type dialContext = func(ctx context.Context, network, address string) (net.Conn, error)
 
 // NewClient returns a Client instance ready for communication with the given
 // server endpoint. It will use the latest remote API version available in the
@@ -201,6 +206,36 @@ func (c *Client) SetTimeout(t time.Duration) {
 	if c.httpClient != nil {
 		c.httpClient.Timeout = t
 	}
+}
+
+// GetDialContext returns the current DialContext function, or nil if there is none.
+func (c *Client) GetDialContext() dialContext {
+	c.configLock.RLock()
+	defer c.configLock.RUnlock()
+
+	if c.httpClient == nil {
+		return nil
+	}
+	transport, supported := c.httpClient.Transport.(*http.Transport)
+	if !supported {
+		return nil
+	}
+	return transport.DialContext
+}
+
+// SetDialContext uses the given dial function to establish TCP connections in the HTTPClient.
+func (c *Client) SetDialContext(dial dialContext) error {
+	c.configLock.Lock()
+	defer c.configLock.Unlock()
+
+	if client := c.httpClient; client != nil {
+		transport, supported := client.Transport.(*http.Transport)
+		if !supported {
+			return ErrDialerNotSupported
+		}
+		transport.DialContext = dial
+	}
+	return nil
 }
 
 func (c *Client) checkAPIVersion() error {

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -240,6 +241,28 @@ func TestSetAuth(t *testing.T) {
 	_, err = client.do("POST", "/xxx", doOptions{})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSetDialContext(t *testing.T) {
+	client, err := NewClient("http://localhost:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dialerCalled := false
+	dialContext := func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialerCalled = true
+		return nil, fmt.Errorf("not implemented")
+	}
+	if err := client.SetDialContext(dialContext); err != nil {
+		t.Fatalf("Failed to set DialContext: %v", err)
+	}
+
+	if err := client.Ping(); err == nil {
+		t.Error("Expected Ping() to return an error")
+	}
+	if !dialerCalled {
+		t.Error("Expected custom DialContext to be called")
 	}
 }
 


### PR DESCRIPTION
This adds a configurable DialContext function to the client library,
which will be invoked to create HTTP/HTTPS connections.

Allowing a custom DialContext captures a wide variety of use cases and
behaviors by delegating the responsibility to the DialContext function.

For example, users can set dial timeouts, share connections, or
tunnel/proxy connections using custom logic.

**Note to reviewers**

This change is needed for kubernetes maintenance of the legacy storage drivers.