### PR TITLE
Adds custom generator template to add accessors

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -11,13 +11,24 @@ help: ## Display this help.
 
 build: generate customise ## Re-generates the API from openapi.yaml.
 
-generate: ## Runs the openapi-generator on openapi.yaml.
+generate: generate-base generate-custom ## Runs the openapi-generator on openapi.yaml.
+generate-base:
 	docker run --rm -v `pwd`:/local -u `id -u ${USER}`:`id -g ${USER}` \
 		openapitools/openapi-generator-cli:latest generate \
 		--strict-spec=true \
 		--additional-properties enumClassPrefix=true \
 		--additional-properties packageName=api \
 		--additional-properties packageVersion=$(VERSION) \
+		-i /local/openapi.yaml -g go -o /local
+generate-custom:
+	docker run --rm -v `pwd`:/local -u `id -u ${USER}`:`id -g ${USER}` \
+		openapitools/openapi-generator-cli:latest generate \
+		--strict-spec=true \
+		--additional-properties enumClassPrefix=true \
+		--additional-properties packageName=api \
+		--additional-properties packageVersion=$(VERSION) \
+		--global-property models="Node" \
+		-t /local/templates \
 		-i /local/openapi.yaml -g go -o /local
 
 customise:  ## Applies customisations to the generated API.
@@ -27,5 +38,3 @@ customise:  ## Applies customisations to the generated API.
 clean: ## Removes generated files.
 	rm -f .openapi-generator-ignore .gitignore git_push.sh .travis.yml *.go go.mod go.sum
 	rm -rf .openapi-generator/ api/ docs/
-
-

--- a/v2/model_node.go
+++ b/v2/model_node.go
@@ -37,3 +37,18 @@ type Node struct {
 	// An opaque representation of an entity version at the time it was obtained from the API. All operations that mutate the entity must include this version field in the request unchanged. The format of this type is undefined and may change but the defined properties will not change. 
 	Version string `json:"version,omitempty"`
 }
+
+// GetID returns the object ID.
+func (t *Node) GetID() string {
+	return t.Id
+}
+
+// GetName returns the object name.
+func (t *Node) GetName() string {
+	return t.Name
+}
+
+// GetLabels returns the object's labels.
+func (t *Node) GetLabels() map[string]string {
+	return t.Labels
+}

--- a/v2/templates/model.mustache
+++ b/v2/templates/model.mustache
@@ -1,0 +1,58 @@
+{{>partial_header}}
+package {{packageName}}
+{{#models}}
+{{#imports}}
+{{#-first}}
+import (
+{{/-first}}
+	"{{import}}"
+{{#-last}}
+)
+{{/-last}}
+{{/imports}}
+{{#model}}
+{{#isEnum}}
+// {{{classname}}} {{#description}}{{{.}}}{{/description}}{{^description}}the model '{{{classname}}}'{{/description}}
+type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{{name}}}
+const (
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{^-first}}
+	{{/-first}}
+	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = {{{value}}}
+	{{/enumVars}}
+	{{/allowableValues}}
+)
+{{/isEnum}}
+{{^isEnum}}
+// {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
+type {{classname}} struct {
+{{#allVars}}
+{{^-first}}
+{{/-first}}
+{{#description}}
+	// {{{description}}}
+{{/description}}
+	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+{{/allVars}}
+}
+
+// GetID returns the object ID.
+func (t *{{classname}}) GetID() string {
+	return t.Id
+}
+
+// GetName returns the object name.
+func (t *{{classname}}) GetName() string {
+	return t.Name
+}
+
+// GetLabels returns the object's labels.
+func (t *{{classname}}) GetLabels() map[string]string {
+	return t.Labels
+}
+{{/isEnum}}
+{{/model}}
+{{/models}}


### PR DESCRIPTION
Add accessors to the Node object for Name, Namespace and Labels.  This allows for easier mocking.

I'll add something similar for Volumes when needed.