### PR TITLE
update openapi spec - includes easier type for NodeToDriveMapping

### DIFF
--- a/autogenerated/api/openapi.yaml
+++ b/autogenerated/api/openapi.yaml
@@ -2192,7 +2192,10 @@ paths:
                   pattern: ^[a-z0-9.\-]{1,253}$
                   type: string
                 nodeToDriveMapping:
-                  additionalProperties: {}
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
                   example:
                     node1:
                     - /drive1
@@ -2499,7 +2502,10 @@ paths:
                 version: NDI0MjQyNDI0MjQyNDI0MjQy
               properties:
                 nodeToDriveMapping:
-                  additionalProperties: {}
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
                   example:
                     node1:
                     - /drive1
@@ -7300,6 +7306,7 @@ components:
           - /drive2
           node2:
           - /drive3
+          node3: []
         name: fast-pool
         id: c5666b58-b805-4215-ab4a-cb094948ccc6
         version: NDI0MjQyNDI0MjQyNDI0MjQy
@@ -7316,13 +7323,17 @@ components:
           example: fast-pool
           type: string
         nodeToDriveMapping:
-          additionalProperties: {}
+          additionalProperties:
+            items:
+              type: string
+            type: array
           example:
             node1:
             - /drive1
             - /drive2
             node2:
             - /drive3
+            node3: []
           type: object
         createdAt:
           description: |
@@ -7352,6 +7363,19 @@ components:
           example: NDI0MjQyNDI0MjQyNDI0MjQy
           maxLength: 30
           type: string
+      type: object
+    NodeToDriveMapping:
+      additionalProperties:
+        items:
+          type: string
+        type: array
+      example:
+        node1:
+        - /drive1
+        - /drive2
+        node2:
+        - /drive3
+        node3: []
       type: object
     Licence:
       description: |
@@ -7752,7 +7776,10 @@ components:
           pattern: ^[a-z0-9.\-]{1,253}$
           type: string
         nodeToDriveMapping:
-          additionalProperties: {}
+          additionalProperties:
+            items:
+              type: string
+            type: array
           example:
             node1:
             - /drive1
@@ -7778,7 +7805,10 @@ components:
         version: NDI0MjQyNDI0MjQyNDI0MjQy
       properties:
         nodeToDriveMapping:
-          additionalProperties: {}
+          additionalProperties:
+            items:
+              type: string
+            type: array
           example:
             node1:
             - /drive1

--- a/autogenerated/docs/CreatePoolData.md
+++ b/autogenerated/docs/CreatePoolData.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** | The name of the pool  | 
-**NodeToDriveMapping** | **map[string]interface{}** |  | 
+**NodeToDriveMapping** | [**map[string][]string**](array.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/autogenerated/docs/Pool.md
+++ b/autogenerated/docs/Pool.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** | A unique identifier for a pool. The format of this type is undefined and may change but the defined properties will not change..  | [optional] 
 **Name** | **string** | The name of the pool  | [optional] 
-**NodeToDriveMapping** | **map[string]interface{}** |  | [optional] 
+**NodeToDriveMapping** | [**map[string][]string**](array.md) |  | [optional] 
 **CreatedAt** | [**time.Time**](time.Time.md) | The time the entity was created. This timestamp is set by the node that created the entity, and may not be correct if the node&#39;s local clock was skewed. This value is for the user&#39;s informative purposes only, and correctness is not required. String format is RFC3339.  | [optional] [readonly] 
 **UpdatedAt** | [**time.Time**](time.Time.md) | The time the entity was last updated. This timestamp is set by the node that last updated the entity, and may not be correct if the node&#39;s local clock was skewed. This value is for the user&#39;s informative purposes only, and correctness is not required. String format is RFC3339.  | [optional] [readonly] 
 **Version** | **string** | An opaque representation of an entity version at the time it was obtained from the API. All operations that mutate the entity must include this version field in the request unchanged. The format of this type is undefined and may change but the defined properties will not change.  | [optional] 

--- a/autogenerated/docs/UpdatePoolData.md
+++ b/autogenerated/docs/UpdatePoolData.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**NodeToDriveMapping** | **map[string]interface{}** |  | [optional] 
+**NodeToDriveMapping** | [**map[string][]string**](array.md) |  | [optional] 
 **Version** | **string** | An opaque representation of an entity version at the time it was obtained from the API. All operations that mutate the entity must include this version field in the request unchanged. The format of this type is undefined and may change but the defined properties will not change.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/autogenerated/model_create_pool_data.go
+++ b/autogenerated/model_create_pool_data.go
@@ -12,5 +12,5 @@ package api
 type CreatePoolData struct {
 	// The name of the pool 
 	Name string `json:"name"`
-	NodeToDriveMapping map[string]interface{} `json:"nodeToDriveMapping"`
+	NodeToDriveMapping map[string][]string `json:"nodeToDriveMapping"`
 }

--- a/autogenerated/model_pool.go
+++ b/autogenerated/model_pool.go
@@ -17,7 +17,7 @@ type Pool struct {
 	Id string `json:"id,omitempty"`
 	// The name of the pool 
 	Name string `json:"name,omitempty"`
-	NodeToDriveMapping map[string]interface{} `json:"nodeToDriveMapping,omitempty"`
+	NodeToDriveMapping map[string][]string `json:"nodeToDriveMapping,omitempty"`
 	// The time the entity was created. This timestamp is set by the node that created the entity, and may not be correct if the node's local clock was skewed. This value is for the user's informative purposes only, and correctness is not required. String format is RFC3339. 
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 	// The time the entity was last updated. This timestamp is set by the node that last updated the entity, and may not be correct if the node's local clock was skewed. This value is for the user's informative purposes only, and correctness is not required. String format is RFC3339. 

--- a/autogenerated/model_update_pool_data.go
+++ b/autogenerated/model_update_pool_data.go
@@ -10,7 +10,7 @@
 package api
 // UpdatePoolData struct for UpdatePoolData
 type UpdatePoolData struct {
-	NodeToDriveMapping map[string]interface{} `json:"nodeToDriveMapping,omitempty"`
+	NodeToDriveMapping map[string][]string `json:"nodeToDriveMapping,omitempty"`
 	// An opaque representation of an entity version at the time it was obtained from the API. All operations that mutate the entity must include this version field in the request unchanged. The format of this type is undefined and may change but the defined properties will not change. 
 	Version string `json:"version,omitempty"`
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1006,17 +1006,26 @@ components:
                         The name of the pool
                     example: fast-pool
                 nodeToDriveMapping:
-                    type: object
-                    additionalProperties: {}
-                    example: 
-                        node1: ["/drive1", "/drive2"]
-                        node2: ["/drive3"]
+                    $ref: "#/components/schemas/NodeToDriveMapping"
                 createdAt:
                     $ref: "#/components/schemas/CreatedAt"
                 updatedAt:
                     $ref: "#/components/schemas/UpdatedAt"
                 version:
                     $ref: "#/components/schemas/Version"
+
+        NodeToDriveMapping:
+            type: object
+            additionalProperties:
+                type: array,
+                items:
+                    type: string
+            example: {
+                "node1": ["/drive1", "/drive2"],
+                "node2": ["/drive3"],
+                "node3": []
+            }
+
 
         Licence:
             type: object
@@ -2473,13 +2482,9 @@ paths:
                                         The name of the pool
                                     example: "pool1"
                                 nodeToDriveMapping:
-                                    type: object
-                                    additionalProperties: {}
-                                    example: {
-                                        "node1": ["/drive1", "/drive2"],
-                                        "node2": ["/drive3"],
-                                        "node3": []
-                                    }
+                                    $ref: "#/components/schemas/NodeToDriveMapping"
+                                
+                                
             responses:
                 "201":
                     description: The pool was successfully created
@@ -2587,13 +2592,7 @@ paths:
                             title: UpdatePoolData
                             properties:
                                 nodeToDriveMapping:
-                                    type: object
-                                    additionalProperties: {}
-                                    example: {
-                                        "node1": ["/drive1", "/drive2"],
-                                        "node2": ["/drive3"],
-                                        "node3": []
-                                    }
+                                    $ref: "#/components/schemas/NodeToDriveMapping"
                                 version:
                                     $ref: "#/components/schemas/Version"
             responses:


### PR DESCRIPTION
> The original type for `nodeDriveMapping` created a golang type of `map[string]interface{}` which is a nightmare to work with, I've changed it to create a type of `map[string][]string` 