### PR TITLE
update openapi spec

### DIFF
--- a/autogenerated/api/openapi.yaml
+++ b/autogenerated/api/openapi.yaml
@@ -5124,7 +5124,7 @@ paths:
   /namespaces/{namespaceID}/volumes/{id}/add-deployment-on-node:
     put:
       description: |
-        Creates a new replica deployment on a specific node.
+        Creates a new replica deployment on a specific node and updates a volume's number of replicas.
         The new deployment is not excluded from any rules that move, failover or remove deployments and as such it can still be moved elsewhere if the Control Plane thinks wise to do so after being created.
       operationId: addDeploymentOnNode
       parameters:
@@ -6636,8 +6636,10 @@ components:
         strategy:
           default: recommended
           enum:
+          - random
           - recommended
           - topology-aware
+          - fixed-topology
           type: string
         options:
           $ref: '#/components/schemas/Strategy_options'
@@ -6659,6 +6661,12 @@ components:
         A unique identifier for a volume. The format of this type is undefined and may change but the defined properties will not change.
       example: c5666b58-b805-4215-ab4a-cb094948ccc6
       type: string
+    SnapshotID:
+      description: |
+        A unique identifier for a snapshot.
+      maximum: 18446744073709551615
+      minimum: 0
+      type: integer
     DeploymentID:
       description: |
         A unique identifier for a volume deployment. The format of this type is undefined and may change but the defined properties will not change.
@@ -6847,8 +6855,8 @@ components:
             createdAt: 2000-01-23T04:56:07.000+00:00
             name: name
             location: location
-            id: id
-            sizeBytes: 0.8008281904610115
+            id: 2147483647
+            sizeBytes: 6.027456183070403
         topologyLabels:
           preferredZones:
           - preferredZones
@@ -6921,7 +6929,7 @@ components:
               serviceEndpoint: serviceEndpoint
             id: c5666b58-b805-4215-ab4a-cb094948ccc6
             parentInfo:
-              snapshotID: snapshotID
+              snapshotID: 2147483647
               namespaceID: namespaceID
               id: id
             updatedAt: 2019-03-29T23:13:13Z
@@ -6970,7 +6978,7 @@ components:
           serviceEndpoint: serviceEndpoint
         id: c5666b58-b805-4215-ab4a-cb094948ccc6
         parentInfo:
-          snapshotID: snapshotID
+          snapshotID: 2147483647
           namespaceID: namespaceID
           id: id
         updatedAt: 2019-03-29T23:13:13Z
@@ -7138,7 +7146,7 @@ components:
           serviceEndpoint: serviceEndpoint
         id: c5666b58-b805-4215-ab4a-cb094948ccc6
         parentInfo:
-          snapshotID: snapshotID
+          snapshotID: 2147483647
           namespaceID: namespaceID
           id: id
         updatedAt: 2019-03-29T23:13:13Z
@@ -7394,13 +7402,17 @@ components:
         createdAt: 2000-01-23T04:56:07.000+00:00
         name: name
         location: location
-        id: id
-        sizeBytes: 0.8008281904610115
+        id: 2147483647
+        sizeBytes: 6.027456183070403
       properties:
         name:
           type: string
         id:
-          type: string
+          description: |
+            A unique identifier for a snapshot.
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
         location:
           type: string
         createdAt:
@@ -7415,7 +7427,7 @@ components:
       type: object
     ParentInfo:
       example:
-        snapshotID: snapshotID
+        snapshotID: 2147483647
         namespaceID: namespaceID
         id: id
       properties:
@@ -7424,7 +7436,11 @@ components:
         namespaceID:
           type: string
         snapshotID:
-          type: string
+          description: |
+            A unique identifier for a snapshot.
+          maximum: 18446744073709551615
+          minimum: 0
+          type: integer
       type: object
     Namespace:
       example:
@@ -8581,7 +8597,7 @@ components:
         topologyKey:
           default: topology.kubernetes.io/zone
           description: |
-            Indicates the node label used to decribe the topology used for data placement decisions. If two nodes are  labelled with this key and have identical values  for that label, the scheduler treats both nodes  as being in the same topology domain.  When topology-aware provisioning is enabled,  the scheduler tries to spread a volume's master  and replica copies across different topology domains.
+            Indicates the node label used to decribe the topology used for data placement decisions. If two nodes are  labelled with this key and have identical values  for that label, the scheduler treats both nodes  as being in the same topology domain.  When topology-aware provisioning is enabled,  the scheduler uses this label for that purpose.
           example: my.custom.zone.label
           type: string
     UserSession_allOf_session:

--- a/autogenerated/api_default.go
+++ b/autogenerated/api_default.go
@@ -34,7 +34,7 @@ type AddDeploymentOnNodeOpts struct {
 
 /*
 AddDeploymentOnNode Creates a new replica deployment on a specific node.
-Creates a new replica deployment on a specific node. The new deployment is not excluded from any rules that move, failover or remove deployments and as such it can still be moved elsewhere if the Control Plane thinks wise to do so after being created. 
+Creates a new replica deployment on a specific node and updates a volume&#39;s number of replicas. The new deployment is not excluded from any rules that move, failover or remove deployments and as such it can still be moved elsewhere if the Control Plane thinks wise to do so after being created. 
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param namespaceID ID of a Namespace
  * @param id ID of a Volume

--- a/autogenerated/docs/DefaultApi.md
+++ b/autogenerated/docs/DefaultApi.md
@@ -71,7 +71,7 @@ Method | HTTP request | Description
 
 Creates a new replica deployment on a specific node.
 
-Creates a new replica deployment on a specific node. The new deployment is not excluded from any rules that move, failover or remove deployments and as such it can still be moved elsewhere if the Control Plane thinks wise to do so after being created. 
+Creates a new replica deployment on a specific node and updates a volume's number of replicas. The new deployment is not excluded from any rules that move, failover or remove deployments and as such it can still be moved elsewhere if the Control Plane thinks wise to do so after being created. 
 
 ### Required Parameters
 

--- a/autogenerated/docs/ParentInfo.md
+++ b/autogenerated/docs/ParentInfo.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** |  | [optional] 
 **NamespaceID** | **string** |  | [optional] 
-**SnapshotID** | **string** |  | [optional] 
+**SnapshotID** | **int32** | A unique identifier for a snapshot.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/autogenerated/docs/Snapshot.md
+++ b/autogenerated/docs/Snapshot.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**Id** | **string** |  | [optional] 
+**Id** | **int32** | A unique identifier for a snapshot.  | [optional] 
 **Location** | **string** |  | [optional] 
 **CreatedAt** | [**time.Time**](time.Time.md) |  | [optional] 
 **SizeBytes** | **float32** |  | [optional] 

--- a/autogenerated/docs/StrategyOptions.md
+++ b/autogenerated/docs/StrategyOptions.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**TopologyKey** | **string** | Indicates the node label used to decribe the topology used for data placement decisions. If two nodes are  labelled with this key and have identical values  for that label, the scheduler treats both nodes  as being in the same topology domain.  When topology-aware provisioning is enabled,  the scheduler tries to spread a volume&#39;s master  and replica copies across different topology domains.  | [optional] [default to topology.kubernetes.io/zone]
+**TopologyKey** | **string** | Indicates the node label used to decribe the topology used for data placement decisions. If two nodes are  labelled with this key and have identical values  for that label, the scheduler treats both nodes  as being in the same topology domain.  When topology-aware provisioning is enabled,  the scheduler uses this label for that purpose.  | [optional] [default to topology.kubernetes.io/zone]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/autogenerated/model_parent_info.go
+++ b/autogenerated/model_parent_info.go
@@ -12,5 +12,6 @@ package api
 type ParentInfo struct {
 	Id string `json:"id,omitempty"`
 	NamespaceID string `json:"namespaceID,omitempty"`
-	SnapshotID string `json:"snapshotID,omitempty"`
+	// A unique identifier for a snapshot. 
+	SnapshotID int32 `json:"snapshotID,omitempty"`
 }

--- a/autogenerated/model_snapshot.go
+++ b/autogenerated/model_snapshot.go
@@ -14,7 +14,8 @@ import (
 // Snapshot struct for Snapshot
 type Snapshot struct {
 	Name string `json:"name,omitempty"`
-	Id string `json:"id,omitempty"`
+	// A unique identifier for a snapshot. 
+	Id int32 `json:"id,omitempty"`
 	Location string `json:"location,omitempty"`
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 	SizeBytes float32 `json:"sizeBytes,omitempty"`

--- a/autogenerated/model_strategy_options.go
+++ b/autogenerated/model_strategy_options.go
@@ -10,6 +10,6 @@
 package api
 // StrategyOptions Used together with topology-aware strategy to further specify how the placement should be done. 
 type StrategyOptions struct {
-	// Indicates the node label used to decribe the topology used for data placement decisions. If two nodes are  labelled with this key and have identical values  for that label, the scheduler treats both nodes  as being in the same topology domain.  When topology-aware provisioning is enabled,  the scheduler tries to spread a volume's master  and replica copies across different topology domains. 
+	// Indicates the node label used to decribe the topology used for data placement decisions. If two nodes are  labelled with this key and have identical values  for that label, the scheduler treats both nodes  as being in the same topology domain.  When topology-aware provisioning is enabled,  the scheduler uses this label for that purpose. 
 	TopologyKey string `json:"topologyKey,omitempty"`
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -425,8 +425,10 @@ components:
                 strategy:
                     type: string
                     enum:
+                        - random
                         - recommended
                         - topology-aware
+                        - fixed-topology
                     default: recommended
                 options:
                     type: object
@@ -442,8 +444,7 @@ components:
                                 for that label, the scheduler treats both nodes 
                                 as being in the same topology domain. 
                                 When topology-aware provisioning is enabled, 
-                                the scheduler tries to spread a volume's master 
-                                and replica copies across different topology domains.
+                                the scheduler uses this label for that purpose.
                     nullable: true
                     description: >
                         Used together with topology-aware strategy to further
@@ -484,6 +485,13 @@ components:
                 The format of this type is undefined and may change but the
                 defined properties will not change.
             example: c5666b58-b805-4215-ab4a-cb094948ccc6
+
+        SnapshotID:
+            type: integer
+            description: >
+                A unique identifier for a snapshot.
+            minimum: 0
+            maximum: 18446744073709551615
 
         DeploymentID:
             type: string
@@ -886,7 +894,7 @@ components:
                 name:
                     type: string
                 id: 
-                    type: string 
+                    $ref: "#/components/schemas/SnapshotID"
                 location: 
                     type: string 
                 createdAt: 
@@ -908,7 +916,7 @@ components:
                 namespaceID:
                     type: string 
                 snapshotID:
-                    type: string
+                    $ref: "#/components/schemas/SnapshotID"
 
         Namespace:
             type: object
@@ -3608,7 +3616,8 @@ paths:
             summary: Creates a new replica deployment on a specific node.
             operationId: addDeploymentOnNode
             description: >
-                Creates a new replica deployment on a specific node.
+                Creates a new replica deployment on a specific node and
+                updates a volume's number of replicas.
 
                 The new deployment is not excluded from any rules that move,
                 failover or remove deployments and as such it can still be moved


### PR DESCRIPTION
Updates the go-api spec to correspond with the control plane's master branch. 

The main change is the change to the SnapshotID types, it's now a int32 instead of a string